### PR TITLE
change how devtools are loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ on the boot wiki.
 After you've done this you can just run:
 
 ```
-$ boot lein-generate
+$ boot generate
 ```
 
 to create the `project.clj` file.  You can then import the repository

--- a/build.boot
+++ b/build.boot
@@ -38,7 +38,7 @@
                     [re-frame]
                     [re-com]
                     [com.andrewmcveigh/cljs-time "0.5.0"]
-                    
+
                     [adzerk/boot-cljs]
                     [adzerk/boot-cljs-repl]
                     [adzerk/boot-reload]
@@ -79,18 +79,19 @@
 (deftask production []
          (task-options! cljs {:optimizations    :advanced
                               :compiler-options {:language-in     :ecmascript5
-                                                 :closure-defines {'sixsq.slipstream.webui/DEV false
-                                                                   'goog.DEBUG                 false}}})
+                                                 :closure-defines {'sixsq.slipstream.webui/LOGGING_LEVEL "warn"
+                                                                   'goog.DEBUG                           false}}})
          identity)
 
 (deftask development []
          (task-options! cljs {:optimizations    :none
                               :source-map       true
-                              :compiler-options {:language-in     :ecmascript5
-                                                 :closure-defines {'sixsq.slipstream.webui/DEV      true
-                                                                   'sixsq.slipstream.webui/HOST_URL "https://nuv.la"
+                              :compiler-options {           ;:preloads        '[devtools.preload]
+                                                 :language-in     :ecmascript5
+                                                 :closure-defines {'sixsq.slipstream.webui/LOGGING_LEVEL "info"
+                                                                   'sixsq.slipstream.webui/HOST_URL      "https://nuv.la"
                                                                    ;'sixsq.slipstream.webui/CONTEXT  ""
-                                                                   'goog.DEBUG                      true}}}
+                                                                   'goog.DEBUG                           true}}}
                         reload {:on-jsload 'sixsq.slipstream.webui/init})
          identity)
 

--- a/src/cljs/sixsq/slipstream/webui.cljs
+++ b/src/cljs/sixsq/slipstream/webui.cljs
@@ -1,7 +1,6 @@
 (ns sixsq.slipstream.webui
   (:require
     [clojure.string :as str]
-    [devtools.core :as devtools]
     [reagent.core :as reagent]
     [re-frame.core :refer [dispatch dispatch-sync]]
     [taoensso.timbre :as timbre]
@@ -18,20 +17,20 @@
     [sixsq.slipstream.webui.widget.history.events]))
 
 ;;
-;; debugging tools
+;; This option is not compatible with other platforms, notably nodejs.
+;; Use instead the logging calls to provide console output.
 ;;
-;; Turn this on or off with:
-;;
-;; {:compiler-options {:closure-defines {'sixsq.slipstream.webui/DEV false}}
-;;
-(goog-define DEV false)
-(if (identical? DEV true)
-  (do
-    (devtools/install!)
-    (enable-console-print!)
-    (timbre/set-level! :info))
-  (timbre/set-level! :warn))
+;; (enable-console-print!)  ;; do not activate
 
+;;
+;; debugging log level
+;;
+;; Set the value like this:
+;;
+;; {:compiler-options {:closure-defines {'sixsq.slipstream.webui/LOGGING_LEVEL "info"}}
+;;
+(goog-define LOGGING_LEVEL "info")
+(timbre/set-level! (keyword LOGGING_LEVEL))
 
 ;;
 ;; determine the host url


### PR DESCRIPTION
With the upgrade of the cljs tooling there is a new recommended way to load the devtools.  Switch to the recommended method.  Switch from DEV to LOGGING_LEVEL flag to make it more descriptive of what it does now.
