### PR TITLE
use modal for login

### DIFF
--- a/resources/webui/themes/default/css/webui.css
+++ b/resources/webui/themes/default/css/webui.css
@@ -135,3 +135,11 @@ html, body {
     background-color: rgba(255, 255, 255, 0.25);
     text-decoration: none;
 }
+
+/*
+   Overrides the colors set in the header, when modal panels
+   are anchored there.
+*/
+.rc-modal-panel {
+    color: black;
+}

--- a/src/cljs/sixsq/slipstream/authn.cljs
+++ b/src/cljs/sixsq/slipstream/authn.cljs
@@ -51,6 +51,7 @@
   (log/info "using slipstream server:" @SLIPSTREAM_URL)
   (log/info "using path prefix:" @PATH_PREFIX)
   (dispatch-sync [:evt.webui.main/initialize-db])
+  (dispatch-sync [:evt.webui.authn/no-modal-login])
   (dispatch-sync [:evt.webui.main/initialize-client @SLIPSTREAM_URL])
   (dispatch-sync [:evt.webui.main/load-cloud-entry-point])
   (dispatch-sync [:evt.webui.history/initialize @PATH_PREFIX])

--- a/src/cljs/sixsq/slipstream/webui/db.cljs
+++ b/src/cljs/sixsq/slipstream/webui/db.cljs
@@ -52,7 +52,6 @@
 ;; authentication state
 ;;
 
-
 (s/def :webui.authn/id string?)
 (s/def :webui.authn/label string?)
 (s/def :webui.authn/group (s/nilable string?))
@@ -67,6 +66,8 @@
                                                     :webui.authn/params-desc]))
 
 
+(s/def :webui.authn/use-modal? boolean?)
+(s/def :webui.authn/show-modal? boolean?)
 (s/def :webui.authn/total nat-int?)
 (s/def :webui.authn/count nat-int?)
 (s/def :webui.authn/redirect-uri string?)
@@ -75,7 +76,9 @@
 (s/def :webui.authn/methods (s/coll-of :webui.authn/method-defn))
 (s/def :webui.authn/forms (s/map-of string? map?))
 
-(s/def :webui.authn/authn (only-keys :req-un [:webui.authn/total
+(s/def :webui.authn/authn (only-keys :req-un [:webui.authn/use-modal?
+                                              :webui.authn/show-modal?
+                                              :webui.authn/total
                                               :webui.authn/count
                                               :webui.authn/redirect-uri
                                               :webui.authn/error-message
@@ -186,7 +189,9 @@
 
    :modules-data          nil
 
-   :authn                 {:total         0
+   :authn                 {:use-modal?    true
+                           :show-modal?   false
+                           :total         0
                            :count         0
                            :redirect-uri  "/webui/login"
                            :error-message nil

--- a/src/cljs/sixsq/slipstream/webui/panel/authn/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/panel/authn/events.cljs
@@ -133,3 +133,21 @@
   (fn [db [_]]
     (assoc-in db [:authn :error-message] nil)))
 
+(reg-event-db
+  :evt.webui.authn/no-modal-login
+  [db/debug-interceptors trim-v]
+  (fn [db [_]]
+    (assoc-in db [:authn :use-modal?] false)))
+
+(reg-event-db
+  :evt.webui.authn/show-modal
+  [db/debug-interceptors trim-v]
+  (fn [db [_]]
+    (assoc-in db [:authn :show-modal?] true)))
+
+(reg-event-db
+  :evt.webui.authn/hide-modal
+  [db/debug-interceptors trim-v]
+  (fn [db [_]]
+    (assoc-in db [:authn :show-modal?] false)))
+

--- a/src/cljs/sixsq/slipstream/webui/panel/authn/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/panel/authn/events.cljs
@@ -128,6 +128,12 @@
         (assoc-in [:authn :error-message] error-message))))
 
 (reg-event-db
+  :evt.webui.authn/set-error-message
+  [db/debug-interceptors trim-v]
+  (fn [db [error-message]]
+    (assoc-in db [:authn :error-message] error-message)))
+
+(reg-event-db
   :evt.webui.authn/clear-error-message
   [db/debug-interceptors trim-v]
   (fn [db [_]]

--- a/src/cljs/sixsq/slipstream/webui/panel/authn/subs.cljs
+++ b/src/cljs/sixsq/slipstream/webui/panel/authn/subs.cljs
@@ -7,6 +7,12 @@
 (reg-sub :webui.authn/session
          (fn [db _] (-> db :authn :session)))
 
+(reg-sub :webui.authn/use-modal?
+         (fn [db _] (-> db :authn :use-modal?)))
+
+(reg-sub :webui.authn/show-modal?
+         (fn [db _] (-> db :authn :show-modal?)))
+
 (reg-sub :webui.authn/total
          (fn [db _] (-> db :authn :total)))
 

--- a/src/cljs/sixsq/slipstream/webui/panel/authn/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/panel/authn/views.cljs
@@ -15,8 +15,13 @@
   []
   (let [session (subscribe [:webui.authn/session])
         use-modal? (subscribe [:webui.authn/use-modal?])
-        show-modal? (subscribe [:webui.authn/show-modal?])]
+        show-modal? (subscribe [:webui.authn/show-modal?])
+        error-message (subscribe [:webui.authn/error-message])]
     (fn []
+      (if @error-message
+        (if @session
+          (dispatch [:evt.webui.authn/clear-error-message])
+          (dispatch [:evt.webui.authn/show-modal])))
       (if @use-modal?
         (when @show-modal?
           [modal-panel

--- a/src/cljs/sixsq/slipstream/webui/panel/authn/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/panel/authn/views.cljs
@@ -1,7 +1,7 @@
 (ns sixsq.slipstream.webui.panel.authn.views
   (:require
     [re-frame.core :refer [dispatch subscribe]]
-    [re-com.core :refer [v-box title]]
+    [re-com.core :refer [v-box title modal-panel]]
     [sixsq.slipstream.webui.panel.authn.effects]
     [sixsq.slipstream.webui.panel.authn.events]
     [sixsq.slipstream.webui.panel.authn.subs]
@@ -13,12 +13,21 @@
   "This panel shows the login controls if there is no active user session;
    otherwise it shows the details of the session."
   []
-  (let [session (subscribe [:webui.authn/session])]
+  (let [session (subscribe [:webui.authn/session])
+        use-modal? (subscribe [:webui.authn/use-modal?])
+        show-modal? (subscribe [:webui.authn/show-modal?])]
     (fn []
-      [v-box
-       :children [(if @session
+      (if @use-modal?
+        (when @show-modal?
+          [modal-panel
+           :backdrop-on-click #(dispatch [:evt.webui.authn/hide-modal])
+           :child (if @session
                     [session/session-info]
-                    [forms/login-controls])]])))
+                    [forms/login-controls])])
+        [v-box
+         :children [(if @session
+                      [session/session-info]
+                      [forms/login-controls])]]))))
 
 (defmethod resource/render "login"
   [path query-params]

--- a/src/cljs/sixsq/slipstream/webui/panel/empty/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/panel/empty/views.cljs
@@ -11,7 +11,6 @@
 (defn empty-panel
   []
   (fn []
-    (dispatch [:evt.webui.empty/redirect-login])
     [v-box
      :children [[:div]]]))
 

--- a/src/cljs/sixsq/slipstream/webui/routes.cljs
+++ b/src/cljs/sixsq/slipstream/webui/routes.cljs
@@ -5,6 +5,7 @@
     [sixsq.slipstream.webui.utils :as utils]))
 
 (defroute "/*" {path :* query-params :query-params}
+          (dispatch [:evt.webui.authn/set-error-message (:error query-params)])
           (dispatch [:set-resource (utils/parse-resource-path path) query-params]))
 
 (defroute "*" {path :*}


### PR DESCRIPTION
Switch to using a modal panel for login and session information.  Can be turned off by dispatching the event `:evt.webui.authn/no-modal-login`, which is the default for the `authn.cljs` file used for the Nuvla login.
