### PR TITLE
Query params and filter workaround controlled value issue

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/cimi/spec.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi/spec.cljs
@@ -62,7 +62,7 @@
                                       :$select      nil
                                       :$aggregation nil}
                ::loading?            false
-               ::filter-visible?     false
+               ::filter-visible?     true
                ::aggregations        nil
                ::collection          nil
                ::collection-name     nil

--- a/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
@@ -181,8 +181,7 @@
 (defn search-header []
   (let [tr (subscribe [::i18n-subs/tr])
         filter-visible? (subscribe [::cimi-subs/filter-visible?])
-        query-params (subscribe [::cimi-subs/query-params])
-        nav-query-params (subscribe [::main-subs/nav-query-params])]
+        query-params (subscribe [::cimi-subs/query-params])]
     (fn []
       ;; reset visible values of parameters
       (let [{:keys [$first $last $filter $select $aggregation $orderby]} @query-params]

--- a/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
@@ -182,90 +182,68 @@
   (let [tr (subscribe [::i18n-subs/tr])
         filter-visible? (subscribe [::cimi-subs/filter-visible?])
         query-params (subscribe [::cimi-subs/query-params])
-        first-value (reagent/atom nil)
-        last-value (reagent/atom nil)
-        ;filter-value (reagent/atom nil)
-        orderby-value (reagent/atom nil)
-        select-value (reagent/atom nil)
-        aggregation-value (reagent/atom nil)
-        nav-query-params (subscribe [::main-subs/nav-query-params])
-        nav-query-params-local (reagent/atom nil)]
+        nav-query-params (subscribe [::main-subs/nav-query-params])]
     (fn []
       ;; reset visible values of parameters
-
-      (when (and (not-empty @nav-query-params) (nil? @nav-query-params-local))
-        (reset! nav-query-params-local @nav-query-params))
-      (let [{:keys [$first $last $filter $select $aggregation $orderby]} @nav-query-params-local]
+      (let [{:keys [$first $last $filter $select $aggregation $orderby]} @query-params]
         [ui/Form
-         (pr-str @nav-query-params-local)
          [ui/FormField
           [cloud-entry-point-title]]
          (when @filter-visible?
            [ui/FormGroup {:widths "equal"}
             [ui/FormField
-             [ui/Input (cond->
-                         {:type         "number"
-                          :min          0
-                          :label        (@tr [:first])
-                          :defaultValue (or $first "0")
-                          :on-blur      #(dispatch [::cimi-events/set-first (-> %1 .-target .-value)])}
-                         (:$first @nav-query-params-local) (merge {:value (:$first @nav-query-params-local)})
-                         )]]
+             ; the key below is a workaround react issue with controlled input cursor position,
+             ; this will force to re-render defaultValue on change of the value
+             ^{:key (str "first:" $first)}
+             [ui/Input {:type         "number"
+                        :min          0
+                        :label        (@tr [:first])
+                        :defaultValue $first
+                        :on-blur      #(dispatch [::cimi-events/set-first (-> %1 .-target .-value)])}]]
 
             [ui/FormField
-             [ui/Input (cond->
-                         {:type         "number"
-                          :min          0
-                          :label        (@tr [:last])
-                          :defaultValue (or $last "20")
-                          :on-blur      #(dispatch [::cimi-events/set-last (-> %1 .-target .-value)])}
-                         (:$last @nav-query-params-local) (merge {:value (:$last @nav-query-params-local)})
-                         )]]
+             ^{:key (str "last:" $last)}
+             [ui/Input {:type         "number"
+                        :min          0
+                        :label        (@tr [:last])
+                        :defaultValue $last
+                        :on-blur      #(dispatch
+                                         [::cimi-events/set-last (-> %1 .-target .-value)])}]]
 
             [ui/FormField
-             [ui/Input (cond->
-                         {:type         "text"
-                          :label        (@tr [:select])
-                          :defaultValue (or $select "")
-                          :on-blur      #(dispatch [::cimi-events/set-select (-> %1 .-target .-value)])}
-                         (:$select @nav-query-params-local) (merge {:value (:$select @nav-query-params-local)})
-                         )]]])
+             ^{:key (str "select:" $select)}
+             [ui/Input {:type         "text"
+                        :label        (@tr [:select])
+                        :defaultValue $select
+                        :on-blur      #(dispatch
+                                         [::cimi-events/set-select (-> %1 .-target .-value)])}]]])
 
          (when @filter-visible?
            [ui/FormGroup {:widths "equal"}
             [ui/FormField
-             [ui/Input (cond->
-                         {:type         "text"
-                          :label        (@tr [:order])
-                          :defaultValue (or $orderby "")
-                          :on-blur      #(dispatch [::cimi-events/set-orderby (-> %1 .-target .-value)])}
-                         (:$orderby @nav-query-params-local) (merge {:value (:$orderby @nav-query-params-local)})
-                         )]]
-
+             ^{:key (str "orderby:" $orderby)}
+             [ui/Input {:type         "text"
+                        :label        (@tr [:order])
+                        :defaultValue $orderby
+                        :on-blur      #(dispatch
+                                         [::cimi-events/set-orderby (-> %1 .-target .-value)])}]]
 
             [ui/FormField
-             [ui/Input (cond->
-                         {:type         "text"
-                          :label        (@tr [:aggregation])
-                          :defaultValue (or $aggregation "")
-                          :on-blur      #(dispatch [::cimi-events/set-aggregation (-> %1 .-target .-value)])}
-                         (:$aggregation @nav-query-params-local) (merge {:value (:$aggregation @nav-query-params-local)})
-                         )]]])
+             ^{:key (str "aggregation:" $aggregation)}
+             [ui/Input {:type         "text"
+                        :label        (@tr [:aggregation])
+                        :defaultValue $aggregation
+                        :on-blur      #(dispatch [::cimi-events/set-aggregation (-> %1 .-target .-value)])}]]])
 
          (when @filter-visible?
            [ui/FormGroup {:widths "equal"}
             [ui/FormField
-             [ui/Input (cond->
-                         {:type         "text"
-                          :label        (@tr [:filter])
-                          :defaultValue (or $filter "")
-                          :on-blur      #(dispatch [::cimi-events/set-filter (-> %1 .-target .-value)])}
-                         (:$filter @nav-query-params-local) (merge {:value (:$filter @nav-query-params-local)})
-                         )]]])
-         (when @nav-query-params-local
-           (reset! nav-query-params-local "consumed"))]
-        )
-      )))
+             ^{:key (str "filter:" $filter)}
+             [ui/Input
+              {:type         "text"
+               :label        (@tr [:filter])
+               :defaultValue $filter
+               :on-blur      #(dispatch [::cimi-events/set-filter (-> %1 .-target .-value)])}]]])]))))
 
 
 (defn format-field-item [selections-atom item]

--- a/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
@@ -182,86 +182,90 @@
   (let [tr (subscribe [::i18n-subs/tr])
         filter-visible? (subscribe [::cimi-subs/filter-visible?])
         query-params (subscribe [::cimi-subs/query-params])
-        first-value (reagent/atom "1")
-        last-value (reagent/atom "20")
-        filter-value (reagent/atom "")
-        orderby-value (reagent/atom "")
-        select-value (reagent/atom "")
-        aggregation-value (reagent/atom "")]
+        first-value (reagent/atom nil)
+        last-value (reagent/atom nil)
+        ;filter-value (reagent/atom nil)
+        orderby-value (reagent/atom nil)
+        select-value (reagent/atom nil)
+        aggregation-value (reagent/atom nil)
+        nav-query-params (subscribe [::main-subs/nav-query-params])
+        nav-query-params-local (reagent/atom nil)]
     (fn []
       ;; reset visible values of parameters
-      (let [{:keys [$first $last $filter $select $aggregation $orderby]} @query-params]
-        (reset! first-value (str (or $first "")))
-        (reset! last-value (str (or $last "")))
-        (reset! filter-value (str (or $filter "")))
-        (reset! orderby-value (str (or $orderby "")))
-        (reset! select-value (str (or $select "")))
-        (reset! aggregation-value (str (or $aggregation ""))))
-      [ui/Form
-       [ui/FormField
-        [cloud-entry-point-title]]
-       (when @filter-visible?
-         [ui/FormGroup {:widths "equal"}
-          [ui/FormField
-           [ui/Input {:type      "number"
-                      :min       0
-                      :label     (@tr [:first])
-                      :value     @first-value
-                      :on-change (cutil/callback :value
-                                                 (fn [v]
-                                                   (reset! first-value v)
-                                                   (dispatch [::cimi-events/set-first v])))}]]
 
-          [ui/FormField
-           [ui/Input {:type      "number"
-                      :min       0
-                      :label     (@tr [:last])
-                      :value     @last-value
-                      :on-change (cutil/callback :value
-                                                 (fn [v]
-                                                   (reset! last-value v)
-                                                   (dispatch [::cimi-events/set-last v])))}]]
+      (when (and (not-empty @nav-query-params) (nil? @nav-query-params-local))
+        (reset! nav-query-params-local @nav-query-params))
+      (let [{:keys [$first $last $filter $select $aggregation $orderby]} @nav-query-params-local]
+        [ui/Form
+         (pr-str @nav-query-params-local)
+         [ui/FormField
+          [cloud-entry-point-title]]
+         (when @filter-visible?
+           [ui/FormGroup {:widths "equal"}
+            [ui/FormField
+             [ui/Input (cond->
+                         {:type         "number"
+                          :min          0
+                          :label        (@tr [:first])
+                          :defaultValue (or $first "0")
+                          :on-blur      #(dispatch [::cimi-events/set-first (-> %1 .-target .-value)])}
+                         (:$first @nav-query-params-local) (merge {:value (:$first @nav-query-params-local)})
+                         )]]
 
-          [ui/FormField
-           [ui/Input {:type      "text"
-                      :label     (@tr [:select])
-                      :value     @select-value
-                      :on-change (cutil/callback :value
-                                                 (fn [v]
-                                                   (reset! select-value v)
-                                                   (dispatch [::cimi-events/set-select v])))}]]])
+            [ui/FormField
+             [ui/Input (cond->
+                         {:type         "number"
+                          :min          0
+                          :label        (@tr [:last])
+                          :defaultValue (or $last "20")
+                          :on-blur      #(dispatch [::cimi-events/set-last (-> %1 .-target .-value)])}
+                         (:$last @nav-query-params-local) (merge {:value (:$last @nav-query-params-local)})
+                         )]]
 
-       (when @filter-visible?
-         [ui/FormGroup {:widths "equal"}
-          [ui/FormField
-           [ui/Input {:type      "text"
-                      :label     (@tr [:order])
-                      :value     @orderby-value
-                      :on-change (cutil/callback :value
-                                                 (fn [v]
-                                                   (reset! orderby-value v)
-                                                   (dispatch [::cimi-events/set-orderby v])))}]]
+            [ui/FormField
+             [ui/Input (cond->
+                         {:type         "text"
+                          :label        (@tr [:select])
+                          :defaultValue (or $select "")
+                          :on-blur      #(dispatch [::cimi-events/set-select (-> %1 .-target .-value)])}
+                         (:$select @nav-query-params-local) (merge {:value (:$select @nav-query-params-local)})
+                         )]]])
+
+         (when @filter-visible?
+           [ui/FormGroup {:widths "equal"}
+            [ui/FormField
+             [ui/Input (cond->
+                         {:type         "text"
+                          :label        (@tr [:order])
+                          :defaultValue (or $orderby "")
+                          :on-blur      #(dispatch [::cimi-events/set-orderby (-> %1 .-target .-value)])}
+                         (:$orderby @nav-query-params-local) (merge {:value (:$orderby @nav-query-params-local)})
+                         )]]
 
 
-          [ui/FormField
-           [ui/Input {:type      "text"
-                      :label     (@tr [:aggregation])
-                      :value     @aggregation-value
-                      :on-change (cutil/callback :value
-                                                 (fn [v]
-                                                   (reset! aggregation-value v)
-                                                   (dispatch [::cimi-events/set-aggregation v])))}]]])
+            [ui/FormField
+             [ui/Input (cond->
+                         {:type         "text"
+                          :label        (@tr [:aggregation])
+                          :defaultValue (or $aggregation "")
+                          :on-blur      #(dispatch [::cimi-events/set-aggregation (-> %1 .-target .-value)])}
+                         (:$aggregation @nav-query-params-local) (merge {:value (:$aggregation @nav-query-params-local)})
+                         )]]])
 
-       (when @filter-visible?
-         [ui/FormGroup {:widths "equal"}
-          [ui/FormField
-           [ui/Input {:type      "text"
-                      :label     (@tr [:filter])
-                      :value     @filter-value
-                      :on-change (cutil/callback :value
-                                                 (fn [v]
-                                                   (reset! filter-value v)
-                                                   (dispatch [::cimi-events/set-filter v])))}]]])])))
+         (when @filter-visible?
+           [ui/FormGroup {:widths "equal"}
+            [ui/FormField
+             [ui/Input (cond->
+                         {:type         "text"
+                          :label        (@tr [:filter])
+                          :defaultValue (or $filter "")
+                          :on-blur      #(dispatch [::cimi-events/set-filter (-> %1 .-target .-value)])}
+                         (:$filter @nav-query-params-local) (merge {:value (:$filter @nav-query-params-local)})
+                         )]]])
+         (when @nav-query-params-local
+           (reset! nav-query-params-local "consumed"))]
+        )
+      )))
 
 
 (defn format-field-item [selections-atom item]

--- a/src/cljs/sixsq/slipstream/webui/deployment/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment/views.cljs
@@ -28,58 +28,48 @@
 
 (defn runs-control []
   (let [tr (subscribe [::i18n-subs/tr])
-        query-params (subscribe [::deployment-subs/query-params])
-        offset-value (reagent/atom (:offset @query-params))
-        limit-value (reagent/atom (:limit @query-params))
-        cloud-value (reagent/atom (:cloud @query-params))
-        activeOnly-value (reagent/atom (-> @query-params :activeOnly js/parseInt zero? not))]
+        query-params (subscribe [::deployment-subs/query-params])]
     (fn []
       (let [{:keys [offset limit cloud activeOnly]} @query-params]
-        (reset! offset-value offset)
-        (reset! limit-value limit)
-        (reset! cloud-value cloud)
-        (reset! activeOnly-value (-> activeOnly js/parseInt zero? not)))
-      [ui/Form
-       [ui/FormGroup
-        [ui/FormField
-         [ui/Input {:type      "number"
-                    :min       0
-                    :label     (@tr [:offset])
-                    :value     @offset-value
-                    :on-change (ui-utils/callback :value
-                                                  (fn [v]
-                                                    (reset! offset-value v)
-                                                    (dispatch [::deployment-events/set-query-params {:offset v}])))}]]
+        [ui/Form
+         [ui/FormGroup
+          [ui/FormField
+           ^{:key (str "offset:" offset)}
+           [ui/Input {:type         "number"
+                      :min          0
+                      :label        (@tr [:offset])
+                      :defaultValue offset
+                      :on-blur      #(dispatch
+                                       [::deployment-events/set-query-params {:offset (-> %1 .-target .-value)}])
+                      }]]
 
-        [ui/FormField
-         [ui/Input {:type      "number"
-                    :min       0
-                    :label     (@tr [:limit])
-                    :value     @limit-value
-                    :on-change (ui-utils/callback :value
-                                                  (fn [v]
-                                                    (reset! limit-value v)
-                                                    (dispatch [::deployment-events/set-query-params {:limit v}])))}]]]
+          [ui/FormField
+           ^{:key (str "limit:" limit)}
+           [ui/Input {:type         "number"
+                      :min          0
+                      :label        (@tr [:limit])
+                      :defaultValue limit
+                      :on-blur      #(dispatch
+                                       [::deployment-events/set-query-params {:limit (-> %1 .-target .-value)}])}]]]
 
-       [ui/FormGroup
-        [ui/FormField
-         [ui/Input {:type      "text"
-                    :label     (@tr [:cloud])
-                    :value     @cloud-value
-                    :on-change (ui-utils/callback :value
-                                                  (fn [v]
-                                                    (reset! cloud-value v)
-                                                    (dispatch [::deployment-events/set-query-params {:cloud v}])))}]]
-        [ui/FormField
-         [ui/Checkbox {:checked   @activeOnly-value
-                       :slider    true
-                       :fitted    true
-                       :label     (@tr [:active?])
-                       :on-change (ui-utils/callback :checked
-                                                     (fn [v]
-                                                       (let [flag (bool->int v)]
-                                                         (reset! activeOnly-value flag)
-                                                         (dispatch [::deployment-events/set-query-params {:activeOnly flag}]))))}]]]])))
+         [ui/FormGroup
+          [ui/FormField
+           ^{:key (str "cloud:" cloud)}
+           [ui/Input {:type         "text"
+                      :label        (@tr [:cloud])
+                      :defaultValue cloud
+                      :on-blur      #(dispatch
+                                       [::deployment-events/set-query-params {:cloud (-> %1 .-target .-value)}])}]]
+          [ui/FormField
+           ^{:key (str "activeOnly:" activeOnly)}
+           [ui/Checkbox {:defaultChecked (-> activeOnly js/parseInt zero? not)
+                         :slider         true
+                         :fitted         true
+                         :label          (@tr [:active?])
+                         :on-change      (ui-utils/callback
+                                           :checked #(dispatch [::deployment-events/set-query-params
+                                                                {:activeOnly (bool->int %)}]))}]]]]
+        ))))
 
 
 (defn menu-bar

--- a/src/cljs/sixsq/slipstream/webui/history/effects.cljs
+++ b/src/cljs/sixsq/slipstream/webui/history/effects.cljs
@@ -20,3 +20,8 @@
   ::navigate-js-location
   (fn [[url]]
     (.replace js/location url)))
+
+(reg-fx
+  ::replace-url-history
+  (fn [[url]]
+    (utils/replace-url-history url)))

--- a/src/cljs/sixsq/slipstream/webui/history/utils.cljs
+++ b/src/cljs/sixsq/slipstream/webui/history/utils.cljs
@@ -92,5 +92,6 @@
 (defn replace-url-history
   "Replace url in history with the given URL."
   [url]
-  (.replaceState js/history (clj->js {}) "" url))
+  (let [short-url (last (str/split url #"/"))]              ;; FIXME: Revisit logic to make sure it works in all cases.
+    (.replaceState js/history nil nil short-url)))
 

--- a/src/cljs/sixsq/slipstream/webui/history/utils.cljs
+++ b/src/cljs/sixsq/slipstream/webui/history/utils.cljs
@@ -88,3 +88,9 @@
           port (.-port location)
           port-field (when-not (str/blank? port) (str ":" port))]
       (str protocol "//" host port-field))))
+
+(defn replace-url-history
+  "Replace url in history with the given URL."
+  [url]
+  (.replaceState js/history (clj->js {}) "" url))
+

--- a/src/cljs/sixsq/slipstream/webui/main/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/main/events.cljs
@@ -28,7 +28,8 @@
       (log/info "navigation query params:" query-params)
       {:db                       (merge db {::main-spec/nav-path         path-vec
                                             ::main-spec/nav-query-params query-params})
-       ::main-fx/action-interval [{:action :clean}]})))
+       ::main-fx/action-interval [{:action :clean}]
+       ::history-fx/replace-url-history [path]})))
 
 (reg-event-fx
   ::action-interval


### PR DESCRIPTION
Connected to #123
- apply query param
- use only input state for performance reason
- use onblur instead on-change for input
- replace query params in path to nothing after taking them into account
- fix cursor position into input when using controlled value