### PR TITLE
terminate run button is not working

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/history/utils.cljs
+++ b/src/cljs/sixsq/slipstream/webui/history/utils.cljs
@@ -89,9 +89,17 @@
           port-field (when-not (str/blank? port) (str ":" port))]
       (str protocol "//" host port-field))))
 
+;;
+;; FIXME: This is currently a no-op because it causes issues when running
+;; with the old UI.  Specifically, it will rename the run URLs, causing
+;; the terminate actions to be applied to the wrong URL.  The side effect
+;; is that the URLs with parameters will not be 'cleaned' on the new UI
+;; for the moment.
+;;
 (defn replace-url-history
   "Replace url in history with the given URL."
   [url]
-  (let [short-url (last (str/split url #"/"))]              ;; FIXME: Revisit logic to make sure it works in all cases.
-    (.replaceState js/history nil nil short-url)))
+  nil
+  #_(let [short-url (last (str/split url #"/"))]
+      (.replaceState js/history nil nil short-url)))
 

--- a/src/cljs/sixsq/slipstream/webui/main/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/main/views.cljs
@@ -60,8 +60,7 @@
                                           (dispatch [::history-events/navigate url]))}
                   [ui/Icon {:name icon}] (@tr [label-kw])])
                [[ui/MenuItem]
-                [i18n-views/locale-dropdown]]
-               ))))))
+                [i18n-views/locale-dropdown]]))))))
 
 
 (defn crumb
@@ -78,6 +77,7 @@
                    (vec (->> @path
                              (map crumb (range))
                              (interpose [ui/BreadcrumbDivider {:icon "chevron right"}]))))))))
+
 
 (defn footer
   []

--- a/src/cljs/sixsq/slipstream/webui/routes.cljs
+++ b/src/cljs/sixsq/slipstream/webui/routes.cljs
@@ -1,18 +1,17 @@
 (ns sixsq.slipstream.webui.routes
   (:require-macros [secretary.core :refer [defroute]])
   (:require
-    [secretary.core :as secretary]
+    [secretary.core :refer [defroute]]
     [re-frame.core :refer [dispatch]]
+    [taoensso.timbre :as log]
 
-    [sixsq.slipstream.webui.history.events :as history-events]
     [sixsq.slipstream.webui.main.events :as main-events]
-    [sixsq.slipstream.webui.authn.events :as authn-events]
-    [taoensso.timbre :as log]))
+    [sixsq.slipstream.webui.authn.events :as authn-events]))
 
 (defn routes []
 
   (defroute "/*" {path :* query-params :query-params}
-            (log/debug "routing /*" path query-params)
+            (log/debug "routing /*:" path query-params)
             (when-let [error (:error query-params)]
               (dispatch [::authn-events/set-error-message error])
               (dispatch [::authn-events/open-modal]))
@@ -20,6 +19,6 @@
               (dispatch [::main-events/set-navigation-info path query-params])))
 
   (defroute "*" {path :*}
-            (log/debug "routing * path")
+            (log/debug "routing *:" path)
             (when (not-empty path)
               (dispatch [::main-events/set-navigation-info path nil]))))


### PR DESCRIPTION
The terminate run button in the old UI was not working correctly because the URL `/run/uuid` was being rewritten as `/uuid` in the history.  The rewriting of URLs has been turned off for now. The consequence is that query parameters in the new UI will not be "beautified" to remove query parameters, etc. 