### PR TITLE
render complex values as strings

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi/views.cljs
@@ -2,11 +2,9 @@
   (:require
     [cljs.pprint :refer [cl-format pprint]]
     [clojure.set :as set]
-
     [clojure.string :as str]
     [re-frame.core :refer [dispatch subscribe]]
     [reagent.core :as reagent]
-
     [sixsq.slipstream.webui.cimi-api.utils :as cimi-api-utils]
     [sixsq.slipstream.webui.cimi-detail.views :as cimi-detail-views]
     [sixsq.slipstream.webui.cimi.events :as cimi-events]
@@ -33,11 +31,12 @@
     [:a {:style {:cursor "pointer"} :on-click on-click} label]))
 
 
+;; FIXME: Provide better visualization of non-string values.
 (defn field-selector
   [field]
   (let [ks (map keyword (str/split field #"/"))]
     (fn [m]
-      (get-in m ks))))
+      (str (get-in m ks)))))
 
 
 (defn remove-column-fn
@@ -70,12 +69,12 @@
   (when entry
     (let [data (row-fn entry)]
       (vec (concat [ui/TableRow]
-                   (vec (map (fn [v] [ui/TableCell v]) data)))))))
+                   (mapv (fn [v] [ui/TableCell v]) data))))))
 
 
 (defn results-table-body [row-fn entries]
   (vec (concat [ui/TableBody]
-               (vec (map (partial results-table-row row-fn) entries)))))
+               (mapv (partial results-table-row row-fn) entries))))
 
 
 (defn results-table [selected-fields entries]

--- a/src/cljs/sixsq/slipstream/webui/dashboard/views_deployments.cljs
+++ b/src/cljs/sixsq/slipstream/webui/dashboard/views_deployments.cljs
@@ -195,13 +195,13 @@
 
           [ui/TableHeader
            (vec (concat [ui/TableRow]
-                        (vec (map (fn [i label] ^{:key (str i "_" label)}
-                        [ui/TableHeaderCell label]) (range) headers))))]
+                        (mapv (fn [i label] ^{:key (str i "_" label)}
+                        [ui/TableHeaderCell label]) (range) headers)))]
 
           (vec (concat [ui/TableBody]
-                       (vec (map (fn [deployment]
-                                   ^{:key (:deployment-uuid deployment)}
-                                   [table-deployment-row deployment]) deployments-data))))
+                       (mapv (fn [deployment]
+                               ^{:key (:deployment-uuid deployment)}
+                               [table-deployment-row deployment]) deployments-data)))
 
           [ui/TableFooter
            [ui/TableRow

--- a/src/cljs/sixsq/slipstream/webui/dashboard/views_vms.cljs
+++ b/src/cljs/sixsq/slipstream/webui/dashboard/views_vms.cljs
@@ -75,13 +75,13 @@
 
           [ui/TableHeader
            (vec (concat [ui/TableRow]
-                        (vec (map (fn [label] ^{:key label} [ui/TableHeaderCell label]) headers))))]
+                        (mapv (fn [label] ^{:key label} [ui/TableHeaderCell label]) headers)))]
 
 
           (vec (concat [ui/TableBody]
-                       (vec (map (fn [{:keys [instance-id connector-href] :as vm}]
-                                   ^{:key (str connector-href "/" instance-id)}
-                                   [table-vm-row vm]) vms-data))))
+                       (mapv (fn [{:keys [instance-id connector-href] :as vm}]
+                               ^{:key (str connector-href "/" instance-id)}
+                               [table-vm-row vm]) vms-data)))
 
           [ui/TableFooter
            [ui/TableRow
@@ -94,5 +94,4 @@
                :totalPages   @total-pages
                :activePage   @page
                :onPageChange (fn [e d]
-                               (dispatch [::dashboard-events/set-page (:activePage (js->clj d :keywordize-keys true))]))
-               }]]]]]]))))
+                               (dispatch [::dashboard-events/set-page (:activePage (js->clj d :keywordize-keys true))]))}]]]]]]))))

--- a/src/cljs/sixsq/slipstream/webui/deployment_detail/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment_detail/views.cljs
@@ -279,7 +279,7 @@
        (@tr [:reports])
        (vec
          (concat [:ul]
-                 (vec (map report-item (:externalObjects @reports)))))
+                 (mapv report-item (:externalObjects @reports))))
        [:p "Reports will be displayed as soon as available. No need to refresh."]])))
 
 

--- a/src/cljs/sixsq/slipstream/webui/messages/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/messages/views.cljs
@@ -94,7 +94,7 @@
         messages (subscribe [::message-subs/messages])]
     (if (seq @messages)
       (vec (concat [ui/ItemGroup]
-                   (vec (map (fn [i msg] [message-item-card @locale i msg]) (range) @messages))))
+                   (mapv (fn [i msg] [message-item-card @locale i msg]) (range) @messages)))
       [ui/Header {:as "h1"} (@tr [:no-messages])])))
 
 

--- a/src/cljs/sixsq/slipstream/webui/utils/form_fields.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/form_fields.cljs
@@ -109,6 +109,6 @@
   [ui/FormField {:required mandatory}
    [:label displayName nbsp (help-popup description)]
    [ui/FormSelect
-    {:options   (vec (map (fn [v] {:value v, :text v}) enum))
+    {:options   (mapv (fn [v] {:value v, :text v}) enum)
      :value     data
      :on-change (ui-callback/value #(update-fn form-id param-name %))}]])

--- a/src/cljs/sixsq/slipstream/webui/utils/forms.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/forms.cljs
@@ -40,11 +40,11 @@
   (let [[hidden-params visible-params] (ordered-params description)
         update-data-fn (partial update-data form-data-atom)
         form-component-fn (partial ff/form-field update-data-fn id)]
-    (vec (map form-component-fn (concat hidden-params visible-params)))))
+    (mapv form-component-fn (concat hidden-params visible-params))))
 
 
 (defn descriptions->options [descriptions]
-  (vec (map (fn [{:keys [id label]}] {:value id, :text (or label id)}) descriptions)))
+  (mapv (fn [{:keys [id label]}] {:value id, :text (or label id)}) descriptions))
 
 
 (defn template-selector

--- a/src/cljs/sixsq/slipstream/webui/utils/resource_details.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/resource_details.cljs
@@ -96,7 +96,7 @@
         [hidden-params visible-params] (form-utils/ordered-params description-with-data)
         update-data-fn (partial update-data text)
         form-component-fn (partial ff/form-field update-data-fn nil)]
-    (vec (map form-component-fn (concat hidden-params visible-params)))))
+    (mapv form-component-fn (concat hidden-params visible-params))))
 
 
 (defn edit-button


### PR DESCRIPTION
Connected to #168. 

Render complex values as strings in CIMI results page to avoid visualization failures.

Also applies `mapv` for common idiom `(vec (map ...))`. 
