### PR TITLE
initial prototype for responsive behavior

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/main/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/main/events.cljs
@@ -11,7 +11,7 @@
 (reg-event-db
   ::set-device
   (fn [db [_ device]]
-    (log/error "setting device:" device)
+    (log/info "setting device:" device)
     (cond-> (assoc db ::main-spec/device device)
             (not (#{:mobile :table} device)) (assoc ::main-spec/sidebar-open? true))))
 

--- a/src/cljs/sixsq/slipstream/webui/main/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/main/events.cljs
@@ -9,9 +9,24 @@
 
 
 (reg-event-db
+  ::set-device
+  (fn [db [_ device]]
+    (log/error "setting device:" device)
+    (cond-> (assoc db ::main-spec/device device)
+            (not (#{:mobile :table} device)) (assoc ::main-spec/sidebar-open? true))))
+
+
+(reg-event-db
+  ::close-sidebar
+  (fn [db _]
+    (assoc db ::main-spec/sidebar-open? false)))
+
+
+(reg-event-db
   ::toggle-sidebar
   (fn [{:keys [::main-spec/sidebar-open?] :as db} _]
     (update db ::main-spec/sidebar-open? not sidebar-open?)))
+
 
 (reg-event-fx
   ::visible

--- a/src/cljs/sixsq/slipstream/webui/main/spec.cljs
+++ b/src/cljs/sixsq/slipstream/webui/main/spec.cljs
@@ -3,6 +3,8 @@
   (:require
     [clojure.spec.alpha :as s]))
 
+(s/def ::device #{:mobile :tablet :computer :large-screen :wide-screen})
+
 (s/def ::sidebar-open? boolean?)
 
 (s/def ::visible? boolean?)
@@ -16,7 +18,8 @@
                           ::nav-path
                           ::nav-query-params]))
 
-(def defaults {::sidebar-open?    true
+(def defaults {::device           :computer
+               ::sidebar-open?    false
                ::visible?         true
                ::nav-path         ["cimi"]
                ::nav-query-params {}})

--- a/src/cljs/sixsq/slipstream/webui/main/subs.cljs
+++ b/src/cljs/sixsq/slipstream/webui/main/subs.cljs
@@ -5,6 +5,11 @@
 
 
 (reg-sub
+  ::device
+  ::main-spec/device)
+
+
+(reg-sub
   ::sidebar-open?
   ::main-spec/sidebar-open?)
 

--- a/src/cljs/sixsq/slipstream/webui/utils/responsive.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/responsive.cljs
@@ -1,0 +1,30 @@
+(ns sixsq.slipstream.webui.utils.responsive)
+
+
+(defn device
+  "Classifies the device being used based on the screen width. On any error
+   (e.g. invalid input), the function will return :computer. The breakpoints
+   are taken from the Semantic UI React code; they are not available in a more
+   convenient form."
+  [width]
+  (try
+    (cond
+      (< width 767) :mobile
+      (< width 991) :tablet
+      (< width 1199) :computer
+      (< width 1919) :large-screen
+      :else :wide-screen)
+    (catch :default _
+      :computer)))
+
+
+(defn callback
+  "Creates a function intended for the on-update callback from the Responsive
+   element. The function extracts the display width, classifies the device, and
+   calls the provided callback with the device keyword."
+  [callback]
+  (fn [evt data]
+    (when callback
+      (-> (.-width data)
+          device
+          callback))))

--- a/src/cljs/sixsq/slipstream/webui/utils/semantic_ui.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/semantic_ui.cljs
@@ -129,6 +129,8 @@
 (def Rail (adapt-component "Rail"))
 (def Ref (adapt-component "Ref"))
 
+(def Responsive (adapt-component "Responsive"))
+
 (def Segment (adapt-component "Segment"))
 (def SegmentGroup (adapt-component "SegmentGroup"))
 


### PR DESCRIPTION
Initial prototype for responsive behavior.  The main page is wrapped in a Responsive element to capture changes to the device width.  This sets the device type in the re-frame database, which can then be used to alter the behavior of the UI.  Currently this is used to decide whether to show the sidebar by default (not shown for mobile or tablet) and whether to automatically close the sidebar on a selection (true for mobile and tablets). 