### PR TITLE
wrap single deployment entry in a vector

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/deployment/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment/views.cljs
@@ -179,7 +179,7 @@
 
      (when-let [{:keys [runs]} @deployments]
        (let [{:keys [item]} runs]
-         [vertical-data-table item]))]))
+         [vertical-data-table (if (map? item) [item] item)]))]))
 
 
 (defn deployments


### PR DESCRIPTION
Connected to #215 

Problem is that the deployment API returns a simple map when there is one item.  Wrap this in a vector to ensure it is treated correctly.