### PR TITLE
initialize data when first mounted

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/dashboard/effects.cljs
+++ b/src/cljs/sixsq/slipstream/webui/dashboard/effects.cljs
@@ -27,9 +27,9 @@
             deployments-uuid (map #(str "deployment/href=\"run/" (:uuid %) "\"") deployments-list)
             filter-str (str/join " or " deployments-uuid)
             vm-aggregation-params (general-utils/prepare-params
-                                    {"$last"        0
-                                     "$aggregation" "terms:deployment/href"
-                                     "$filter"      filter-str})
+                                    {:$last        0
+                                     :$aggregation "terms:deployment/href"
+                                     :$filter      filter-str})
             active-vms (if (not-empty deployments-list)
                          (<! (cimi/search client "virtualMachines" vm-aggregation-params)) {})
             active-vms-per-deployment (->> (get-in active-vms [:aggregations :terms:deployment/href :buckets] [])

--- a/src/cljs/sixsq/slipstream/webui/usage/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/events.cljs
@@ -5,30 +5,54 @@
     [sixsq.slipstream.webui.cimi-api.effects :as cimi-api-fx]
     [sixsq.slipstream.webui.client.spec :as client-spec]
     [sixsq.slipstream.webui.usage.effects :as usage-fx]
-    [sixsq.slipstream.webui.usage.spec :as usage-spec]
-    [sixsq.slipstream.webui.usage.utils :as u]))
+    [sixsq.slipstream.webui.usage.spec :as usage-spec]))
 
 
-(defn get-credentials-map-cofx
-  [client selected-users-roles]
-  (let [users-roles-filter (->>
-                             selected-users-roles
-                             (map #(str "acl/owner/principal = '" % "' or acl/rules/principal = '" % "'"))
-                             (str/join " or "))
+(defn get-credentials-map-cofx-for-callback
+  [callback client selected-users-roles]
+  (let [users-roles-filter (->> selected-users-roles
+                                (map #(str "acl/owner/principal = '" % "' or acl/rules/principal = '" % "'"))
+                                (str/join " or "))
         filter-str (cond-> "type^='cloud-cred-'"
                            (not-empty selected-users-roles) (str " and (" users-roles-filter ")"))]
     {::cimi-api-fx/search [client
                            :credentials
                            {:$select "id,name,description,connector"
                             :$filter filter-str}
-                           #(dispatch [::set-credentials-map %])]}))
+                           callback]}))
+
+
+(def get-credentials-map-cofx (partial get-credentials-map-cofx-for-callback #(dispatch [::set-credentials-map %])))
 
 
 (reg-event-fx
   ::get-credentials-map
   (fn [{{:keys [::client-spec/client
                 ::usage-spec/selected-users-roles] :as db} :db} _]
+    (merge {:db (assoc db ::usage-spec/credentials-map nil
+                          ::usage-spec/selected-credentials nil
+                          ::usage-spec/loading-credentials-map? true
+                          ::usage-spec/totals nil
+                          ::usage-spec/results nil)})
     (get-credentials-map-cofx client selected-users-roles)))
+
+
+(reg-event-fx
+  ::initialize
+  (fn [{{:keys [::client-spec/client
+                ::usage-spec/selected-users-roles] :as db} :db} _]
+    (let [db-update (assoc db ::usage-spec/loading-credentials-map? true
+                              ::usage-spec/loading-totals? false
+                              ::usage-spec/loading-details? false
+                              ::usage-spec/credentials-map nil
+                              ::usage-spec/selected-credentials nil
+                              ::usage-spec/totals nil
+                              ::usage-spec/results nil)]
+      (merge {:db db-update}
+             (get-credentials-map-cofx client selected-users-roles
+                                       #(do
+                                          (dispatch [::set-credentials-map %])
+                                          (dispatch [::fetch-data])))))))
 
 
 (reg-event-db
@@ -38,25 +62,30 @@
           map_id_cred (->> credentials
                            (map #(vector (:id %) %))
                            (into {}))]
-      (-> db
-          (assoc ::usage-spec/credentials-map map_id_cred)
-          (assoc ::usage-spec/loading-credentials-map? false)))))
+      (assoc db ::usage-spec/credentials-map map_id_cred
+                ::usage-spec/loading-credentials-map? false
+                ::usage-spec/totals nil
+                ::usage-spec/results nil))))
 
 
 (reg-event-db
   ::set-selected-credentials
   (fn [db [_ credentials]]
-    (assoc db ::usage-spec/selected-credentials credentials)))
+    (assoc db ::usage-spec/selected-credentials credentials
+              ::usage-spec/totals nil
+              ::usage-spec/results nil)))
 
 
 (reg-event-fx
   ::set-users-roles
   (fn [{{:keys [::client-spec/client
                 ::usage-spec/selected-users-roles] :as db} :db} [_ user]]
-    (merge {:db (-> db
-                    (assoc ::usage-spec/selected-users-roles user)
-                    (assoc ::usage-spec/loading-credentials-map? true)
-                    (assoc ::usage-spec/results nil))}
+    (merge {:db (assoc db ::usage-spec/selected-users-roles user
+                          ::usage-spec/loading-credentials-map? true
+                          ::usage-spec/credentials-map nil
+                          ::usage-spec/selected-credentials nil
+                          ::usage-spec/results nil
+                          ::usage-spec/totals nil)}
            (get-credentials-map-cofx client user))))
 
 
@@ -71,68 +100,63 @@
       db)))
 
 
-(reg-event-fx
-  ::clear-user
-  (fn [{{:keys [::client-spec/client] :as db} :db} _]
-    (merge {:db (-> db
-                    (assoc ::usage-spec/selected-users-roles nil)
-                    (assoc ::usage-spec/loading-credentials-map? true))}
-           (get-credentials-map-cofx client nil))))
-
-
 (reg-event-db
   ::set-date-range
   (fn [db [_ date-range]]
-    (assoc db ::usage-spec/date-range date-range)))
+    (assoc db ::usage-spec/date-range date-range
+              ::usage-spec/totals nil
+              ::usage-spec/results nil)))
 
 
 (reg-event-db
   ::set-totals
   (fn [db [_ totals]]
-    (assoc db ::usage-spec/totals totals)))
+    (assoc db ::usage-spec/loading-totals? false
+              ::usage-spec/totals totals)))
 
 
 (reg-event-db
   ::set-results
   (fn [db [_ results]]
-    (-> db
-        (assoc ::usage-spec/results results)
-        (assoc ::usage-spec/loading? false))))
+    (assoc db ::usage-spec/loading-details? false
+              ::usage-spec/results results)))
 
 
 (reg-event-fx
-  ::fetch-totals
+  ::fetch-data
   (fn [{{:keys [::client-spec/client
+                ::usage-spec/loading-totals?
+                ::usage-spec/loading-details?
                 ::usage-spec/date-range
                 ::usage-spec/selected-credentials
                 ::usage-spec/credentials-map
+                ::usage-spec/loading-credentials-map?
                 ::usage-spec/billable-only?] :as db} :db}]
-    {:db                     (assoc db ::usage-spec/totals nil)
-     ::usage-fx/fetch-totals [client
-                              (-> date-range first .clone .utc .format)
-                              (-> date-range second .clone .utc .format)
-                              (keys credentials-map)
-                              billable-only?
-                              #(dispatch [::set-totals %])]}))
+    (when-not (or loading-totals? loading-details? loading-credentials-map?)
+      (let [start (-> date-range first .clone .utc .format)
+            end (-> date-range second .clone .utc .format)
 
+            creds (vec (take 10 (if (empty? selected-credentials)
+                                  (keys credentials-map)
+                                  selected-credentials)))]
+        {:db                        (assoc db ::usage-spec/loading-totals? true
+                                              ::usage-spec/loading-details? true
+                                              ::usage-spec/totals nil
+                                              ::usage-spec/results nil)
 
-(reg-event-fx
-  ::fetch-meterings
-  (fn [{{:keys [::client-spec/client
-                ::usage-spec/date-range
-                ::usage-spec/selected-credentials
-                ::usage-spec/credentials-map
-                ::usage-spec/billable-only?] :as db} :db}]
-    {:db                        (assoc db ::usage-spec/loading? true
-                                          ::usage-spec/results nil)
-     ::usage-fx/fetch-meterings [client
-                                 (-> date-range first .clone .utc .format)
-                                 (-> date-range second .clone .utc .format)
-                                 (if (empty? selected-credentials)
-                                   (keys credentials-map)
-                                   selected-credentials)
-                                 billable-only?
-                                 #(dispatch [::set-results %])]}))
+         ::usage-fx/fetch-totals    [client
+                                     start
+                                     end
+                                     creds
+                                     billable-only?
+                                     #(dispatch [::set-totals %])]
+
+         ::usage-fx/fetch-meterings [client
+                                     start
+                                     end
+                                     creds
+                                     billable-only?
+                                     #(dispatch [::set-results %])]}))))
 
 
 (reg-event-db
@@ -151,4 +175,6 @@
 (reg-event-db
   ::toggle-billable-only?
   (fn [{:keys [::usage-spec/billable-only?] :as db} _]
-    (assoc db ::usage-spec/billable-only? (not billable-only?))))
+    (assoc db ::usage-spec/billable-only? (not billable-only?)
+              ::usage-spec/totals nil
+              ::usage-spec/results nil)))

--- a/src/cljs/sixsq/slipstream/webui/usage/spec.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/spec.cljs
@@ -5,6 +5,8 @@
     [sixsq.slipstream.webui.usage.utils :as u]))
 
 
+(s/def ::initialized? boolean?)
+
 (s/def ::loading-totals? boolean?)
 
 (s/def ::totals any?)
@@ -35,7 +37,8 @@
 
 (s/def ::is-admin? boolean?)
 
-(s/def ::db (s/keys :req [::loading-totals?
+(s/def ::db (s/keys :req [::initialized?
+                          ::loading-totals?
                           ::loading-details?
                           ::totals
                           ::results
@@ -49,7 +52,8 @@
                           ::billable-only?
                           ::is-admin?]))
 
-(def defaults {::loading-totals?          false
+(def defaults {::initialized?             false
+               ::loading-totals?          false
                ::loading-details?         false
                ::totals                   nil
                ::results                  nil

--- a/src/cljs/sixsq/slipstream/webui/usage/spec.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/spec.cljs
@@ -5,9 +5,11 @@
     [sixsq.slipstream.webui.usage.utils :as u]))
 
 
-(s/def ::loading? boolean?)
+(s/def ::loading-totals? boolean?)
 
 (s/def ::totals any?)
+
+(s/def ::loading-details? boolean?)
 
 (s/def ::results any?)
 
@@ -33,7 +35,8 @@
 
 (s/def ::is-admin? boolean?)
 
-(s/def ::db (s/keys :req [::loading?
+(s/def ::db (s/keys :req [::loading-totals?
+                          ::loading-details?
                           ::totals
                           ::results
                           ::credentials-map
@@ -46,7 +49,8 @@
                           ::billable-only?
                           ::is-admin?]))
 
-(def defaults {::loading?                 false
+(def defaults {::loading-totals?          false
+               ::loading-details?         false
                ::totals                   nil
                ::results                  nil
                ::credentials-map          {}

--- a/src/cljs/sixsq/slipstream/webui/usage/subs.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/subs.cljs
@@ -5,13 +5,18 @@
 
 
 (reg-sub
-  ::loading?
-  ::usage-spec/loading?)
+  ::loading-totals?
+  ::usage-spec/loading-totals?)
 
 
 (reg-sub
   ::totals
   ::usage-spec/totals)
+
+
+(reg-sub
+  ::loading-details?
+  ::usage-spec/loading-details?)
 
 
 (reg-sub

--- a/src/cljs/sixsq/slipstream/webui/usage/subs.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/subs.cljs
@@ -5,6 +5,11 @@
 
 
 (reg-sub
+  ::initialized?
+  ::usage-spec/initialized?)
+
+
+(reg-sub
   ::loading-totals?
   ::usage-spec/loading-totals?)
 

--- a/src/cljs/sixsq/slipstream/webui/usage/utils.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/utils.cljs
@@ -92,9 +92,9 @@
           filter-str (cond-> (str filter-created-str "and (" filter-credentials ")")
                              billable-only? (str " and " billable-filter)
                              true (str " and " vm-filter))
-          request-opts {"$last"        0
-                        "$filter"      filter-str
-                        "$aggregation" compute-aggregations}
+          request-opts {:$last        0
+                        :$filter      filter-str
+                        :$aggregation compute-aggregations}
           response (<! (cimi/search client "meterings" request-opts))]
       (extract-compute-stats response))))
 
@@ -103,12 +103,12 @@
   (go
     (let [filter-created-str (str "snapshot-time>'" date-after "' and snapshot-time<'" date-before "'")
           filter-credentials (str "credentials/href='" credential "'")
-          filter-str (cond-> (str filter-created-str "and (" filter-credentials ")")
+          filter-str (cond-> (str filter-created-str " and (" filter-credentials ")")
                              billable-only? (str " and " billable-filter)
                              true (str " and " vm-filter))
-          request-opts {"$last"        0
-                        "$filter"      filter-str
-                        "$aggregation" compute-aggregations}
+          request-opts {:$last        0
+                        :$filter      filter-str
+                        :$aggregation compute-aggregations}
           response (<! (cimi/search client "meterings" request-opts))]
       (callback
         [credential (extract-compute-stats response)]))))

--- a/src/cljs/sixsq/slipstream/webui/usage/utils.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/utils.cljs
@@ -89,7 +89,7 @@
   (go
     (let [filter-created-str (str "snapshot-time>'" date-after "' and snapshot-time<'" date-before "'")
           filter-credentials (str/join " or " (map #(str "credentials/href='" % "'") credentials))
-          filter-str (cond-> (str filter-created-str "and (" filter-credentials ")")
+          filter-str (cond-> (str filter-created-str " and (" filter-credentials ")")
                              billable-only? (str " and " billable-filter)
                              true (str " and " vm-filter))
           request-opts {:$last        0

--- a/src/cljs/sixsq/slipstream/webui/usage/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/usage/views.cljs
@@ -15,8 +15,7 @@
     [sixsq.slipstream.webui.utils.style :as style]
     [sixsq.slipstream.webui.utils.time :as time]
     [sixsq.slipstream.webui.utils.ui-callback :as ui-callback]
-    [sixsq.slipstream.webui.utils.values :as values]
-    [taoensso.timbre :as log]))
+    [sixsq.slipstream.webui.utils.values :as values]))
 
 
 (defn format [fmt-str & v]
@@ -203,7 +202,7 @@
          :multiple    true
          :search      true
          :selection   true
-         :value       (clj->js @selected-credentials)
+         :value       (clj->js (or @selected-credentials []))
          :onChange    (ui-callback/dropdown ::usage-events/set-selected-credentials)
          :options     (map
                         #(let [{:keys [id name description connector]} %]
@@ -346,15 +345,17 @@
 
 (defn usage
   []
+  (let [initialized? (subscribe [::usage-subs/initialized?])]
 
-  ;; force the data to load when the usage panel is mounted
-  (log/error "dispatch initial load of usage")
-  (dispatch [::usage-events/initialize])
+    ;; force the initialization of the credentials and data only the
+    ;; first time that the usage page is mounted
+    (when-not @initialized?
+      (dispatch [::usage-events/initialize]))
 
-  (fn []
-    [ui/Container {:fluid true}
-     [control-bar]
-     [data-segment]]))
+    (fn []
+      [ui/Container {:fluid true}
+       [control-bar]
+       [data-segment]])))
 
 
 (defmethod panel/render :usage

--- a/src/cljs/sixsq/slipstream/webui/utils/style.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/style.cljs
@@ -10,12 +10,15 @@
 basic
   {:basic  true
    :padded false
-   :style  {:padding 0}})
+   :style  {:padding-top    "inherit"
+            :padding-bottom "inherit"
+            :padding-left   0
+            :padding-right  0}})
 
 
 (def ^{:doc "Options for a Segment with horizontal scroll."}
 autoscroll-x
-  (update-in basic [:style :overflow-x] (constantly "auto")))
+  (assoc-in basic [:style :overflow-x] "auto"))
 
 
 (def ^{:doc "Options for a Segment with evenly spaced content."}
@@ -39,7 +42,7 @@ single-line
 
 (def ^{:doc "Common styles for single-line, selectable tables."}
 selectable
-  (merge single-line {:selectable true
+  (merge single-line {:selectable  true
                       :unstackable true}))
 
 
@@ -55,4 +58,4 @@ acl
          {:celled      true
           :text-align  "center"
           :unstackable true
-          :style {:max-width "100%"}}))
+          :style       {:max-width "100%"}}))


### PR DESCRIPTION
Invalidates and removes data when any controls are changed. Initializes the data with the default settings when the usage page is first mounted; existing data/settings are used after the initialization.

Connected to #250.
