### PR TITLE
monkey patch process variable

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -15,10 +15,12 @@
                                            :after-load       sixsq.slipstream.webui.core/mount-root
                                            :preloads         [devtools.preload]}
 
-                        :compiler-options {:closure-defines {sixsq.slipstream.webui.utils.defines/HOST_URL "https://185.19.28.151"}
-                                           :infer-externs   :auto}
+                        :compiler-options {:closure-defines {sixsq.slipstream.webui.utils.defines/HOST_URL "https://nuv.la"}
+                                           :infer-externs   :auto
+                                           :process-shim    true}
 
 
                         :release          {:closure-defines  {sixsq.slipstream.webui.utils.defines/HOST_URL ""}
                                            :compiler-options {:infer-externs :auto
+                                                              :process-shim  true
                                                               :optimizations :advanced}}}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -16,11 +16,9 @@
                                            :preloads         [devtools.preload]}
 
                         :compiler-options {:closure-defines {sixsq.slipstream.webui.utils.defines/HOST_URL "https://nuv.la"}
-                                           :infer-externs   :auto
-                                           :process-shim    true}
+                                           :infer-externs   :auto}
 
 
                         :release          {:closure-defines  {sixsq.slipstream.webui.utils.defines/HOST_URL ""}
                                            :compiler-options {:infer-externs :auto
-                                                              :process-shim  true
                                                               :optimizations :advanced}}}}}

--- a/src/cljs/sixsq/slipstream/webui/core.cljs
+++ b/src/cljs/sixsq/slipstream/webui/core.cljs
@@ -63,7 +63,17 @@
     (.addEventListener js/document "visibilitychange" callback)))
 
 
+(defn patch-process
+  "patch for npm markdown module that calls into the process object for the
+   current working directory"
+  []
+  (when-not (exists? js/process)
+    (set! js/process (clj->js {})))
+  (aset js/process "cwd" (constantly "/")))
+
+
 (defn ^:export init []
+  (patch-process)
   (dev-setup)
   (dispatch-sync [::db-events/initialize-db])
   (dispatch-sync [::client-events/initialize @SLIPSTREAM_URL])
@@ -75,5 +85,3 @@
   (dispatch [::history-events/initialize @config/path-prefix])
   (mount-root)
   (log/info "finished initialization"))
-
-


### PR DESCRIPTION
Monkey patch the `js/process` variable to provide a `cwd` function.  This is needed by the react-markdown component.