### PR TITLE
make the deployment operations workflow more fluid

### DIFF
--- a/src/cljs/sixsq/slipstream/webui/cimi_api/effects.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi_api/effects.cljs
@@ -45,7 +45,12 @@
   ::edit
   (fn [[client resource-id data callback]]
     (go
-      (callback (<! (cimi/edit client resource-id data))))))
+      (<! (cimi/edit client resource-id data))
+
+      ;; This is done to get a fully updated resource.  If the return
+      ;; value of edit is used, then, for example, the operations are
+      ;; not updated.
+      (callback (<! (cimi/get client resource-id))))))
 
 (reg-fx
   ::add

--- a/src/cljs/sixsq/slipstream/webui/cimi_detail/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/cimi_detail/events.cljs
@@ -8,12 +8,9 @@
     [sixsq.slipstream.webui.client.spec :as client-spec]
     [sixsq.slipstream.webui.history.events :as history-events]
     [sixsq.slipstream.webui.messages.events :as messages-events]
+    [sixsq.slipstream.webui.utils.general :as general]
     [sixsq.slipstream.webui.utils.response :as response]
     [taoensso.timbre :as log]))
-
-
-(defn operation-name [op-uri]
-  (second (re-matches #"^(?:.*/)?(.+)$" op-uri)))
 
 
 (reg-event-fx
@@ -52,7 +49,7 @@
                      (get tpl-resource-key)
                      :href)
           describe-operation (->> operations
-                                  (filter #(= (-> % :rel operation-name) "describe"))
+                                  (filter #(= (-> % :rel general/operation-name) "describe"))
                                   first
                                   :rel)]
       (log/info (:id resource))
@@ -71,6 +68,7 @@
   ::set-description
   (fn [db [_ description]]
     (assoc db ::cimi-detail-spec/description description)))
+
 
 (reg-event-fx
   ::delete
@@ -94,6 +92,7 @@
                                   (dispatch [::history-events/navigate (str "cimi/" collection-name)])))]
        })))
 
+
 (reg-event-fx
   ::edit
   (fn [{{:keys [::client-spec/client] :as db} :db} [_ resource-id data]]
@@ -107,6 +106,7 @@
                                             :content message
                                             :type    :error}]))
                               (dispatch [::set-resource %]))]})))
+
 
 (reg-event-fx
   ::operation

--- a/src/cljs/sixsq/slipstream/webui/deployment/events.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment/events.cljs
@@ -4,8 +4,8 @@
     [re-frame.core :refer [dispatch reg-event-db reg-event-fx]]
     [sixsq.slipstream.webui.cimi-api.effects :as cimi-api-fx]
     [sixsq.slipstream.webui.client.spec :as client-spec]
-    [sixsq.slipstream.webui.messages.events :as messages-events]
     [sixsq.slipstream.webui.deployment.spec :as spec]
+    [sixsq.slipstream.webui.messages.events :as messages-events]
     [sixsq.slipstream.webui.utils.response :as response]))
 
 

--- a/src/cljs/sixsq/slipstream/webui/deployment/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment/views.cljs
@@ -2,12 +2,13 @@
   (:require
     [clojure.string :as str]
     [re-frame.core :refer [dispatch subscribe]]
-    [sixsq.slipstream.webui.deployment-detail.views :as deployment-detail-views]
+    [reagent.core :as reagent]
     [sixsq.slipstream.webui.deployment-detail.utils :as deployment-detail-utils]
+    [sixsq.slipstream.webui.deployment-detail.views :as deployment-detail-views]
     [sixsq.slipstream.webui.deployment.events :as events]
     [sixsq.slipstream.webui.deployment.subs :as subs]
-    [sixsq.slipstream.webui.history.views :as history]
     [sixsq.slipstream.webui.history.events :as history-events]
+    [sixsq.slipstream.webui.history.views :as history]
     [sixsq.slipstream.webui.i18n.subs :as i18n-subs]
     [sixsq.slipstream.webui.main.events :as main-events]
     [sixsq.slipstream.webui.main.subs :as main-subs]
@@ -17,9 +18,7 @@
     [sixsq.slipstream.webui.utils.semantic-ui-extensions :as uix]
     [sixsq.slipstream.webui.utils.style :as style]
     [sixsq.slipstream.webui.utils.time :as time]
-    [sixsq.slipstream.webui.utils.ui-callback :as ui-callback]
-    [reagent.core :as reagent]))
-
+    [sixsq.slipstream.webui.utils.ui-callback :as ui-callback]))
 
 
 (defn deployment-active?
@@ -60,15 +59,15 @@
 (defn stop-button
   [deployment]
   (let [tr (subscribe [::i18n-subs/tr])]
-    [ui/Popup {:content (@tr [:stop])
-               :size "tiny"
+    [ui/Popup {:content  (@tr [:stop])
+               :size     "tiny"
                :position "top center"
-               :trigger (reagent/as-element
-                          [ui/Icon {:name     "close"
-                                    :style    {:cursor "pointer"}
-                                    :color    "red"
-                                    :size     "large"
-                                    :on-click #(dispatch [::events/stop-deployment (:id deployment)])}])}]))
+               :trigger  (reagent/as-element
+                           [ui/Icon {:name     "close"
+                                     :style    {:cursor "pointer"}
+                                     :color    "red"
+                                     :size     "large"
+                                     :on-click #(dispatch [::events/stop-deployment (:id deployment)])}])}]))
 
 
 (defn menu-bar
@@ -171,13 +170,16 @@
                            :padding    "20px"
                            :object-fit "contain"}}]
 
+     (when (deployment-detail-utils/stop-action? deployment)
+       [ui/Label {:corner true
+                  :size   "small"} [stop-button deployment]])
+
      [ui/CardContent {:href     id
                       :on-click (fn [event]
                                   (dispatch [::history-events/navigate id])
                                   (.preventDefault event))}
 
-      (when (deployment-detail-utils/stop-action? deployment)
-        [ui/Label {:as :a :corner true :size "small"} [stop-button deployment]])
+
 
 
       [ui/Segment (merge style/basic {:floated "right"})

--- a/src/cljs/sixsq/slipstream/webui/deployment_detail/views.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment_detail/views.cljs
@@ -8,12 +8,12 @@
     [sixsq.slipstream.webui.deployment-detail.events :as events]
     [sixsq.slipstream.webui.deployment-detail.subs :as subs]
     [sixsq.slipstream.webui.deployment-detail.utils :as deployment-detail-utils]
+    [sixsq.slipstream.webui.deployment-detail.views-operations :as operations]
     [sixsq.slipstream.webui.history.views :as history]
     [sixsq.slipstream.webui.i18n.subs :as i18n-subs]
     [sixsq.slipstream.webui.main.events :as main-events]
     [sixsq.slipstream.webui.utils.collapsible-card :as cc]
     [sixsq.slipstream.webui.utils.general :as general]
-    [sixsq.slipstream.webui.utils.resource-details :as resource-details]
     [sixsq.slipstream.webui.utils.semantic-ui :as ui]
     [sixsq.slipstream.webui.utils.semantic-ui-extensions :as uix]
     [sixsq.slipstream.webui.utils.style :as style]
@@ -430,7 +430,7 @@
         cep (subscribe [::cimi-subs/cloud-entry-point])]
     (vec (concat [ui/Menu {:borderless true}]
 
-                 (resource-details/format-operations nil @deployment (:baseURI @cep) {})
+                 (operations/format-operations nil @deployment (:baseURI @cep) {})
 
                  [[service-link-button]
                   [refresh-button]]))))

--- a/src/cljs/sixsq/slipstream/webui/deployment_detail/views_operations.cljs
+++ b/src/cljs/sixsq/slipstream/webui/deployment_detail/views_operations.cljs
@@ -1,0 +1,23 @@
+(ns sixsq.slipstream.webui.deployment-detail.views-operations
+  (:require
+    [re-frame.core :refer [dispatch]]
+    [sixsq.slipstream.webui.deployment-detail.events :as events]
+    [sixsq.slipstream.webui.utils.general :as general]
+    [sixsq.slipstream.webui.utils.resource-details :as resource-details]
+    ))
+
+
+;; Explicit keys have been added to the operation buttons to avoid react
+;; errors for duplicate keys, which may happen when the data contains :key.
+;; It is probably a bad idea to have a first argument that can be a map
+;; as this will be confused with reagent options.
+(defn operation-button [{:keys [id] :as data} description [label href operation-uri]]
+  (case label
+    "edit" ^{:key "edit"} [resource-details/edit-button data description #(dispatch [::events/edit id %])]
+    "delete" ^{:key "delete"} [resource-details/delete-button data #(dispatch [::events/delete id])]
+    ^{:key operation-uri} [resource-details/other-button label data #(dispatch [::events/operation id operation-uri])]))
+
+
+(defn format-operations [refresh-button {:keys [operations] :as data} baseURI description]
+  (let [ops (map (juxt #(general/operation-name (:rel %)) #(str baseURI (:href %)) :rel) operations)]
+    (vec (concat [refresh-button] (map (partial operation-button data description) ops)))))

--- a/src/cljs/sixsq/slipstream/webui/utils/general.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/general.cljs
@@ -128,3 +128,11 @@
 (defn resource-id->uuid
   [resource-id]
   (-> resource-id (str/split #"/") second))
+
+
+;;
+;; cimi
+;;
+
+(defn operation-name [op-uri]
+  (second (re-matches #"^(?:.*/)?(.+)$" op-uri)))

--- a/src/cljs/sixsq/slipstream/webui/utils/resource_details.cljs
+++ b/src/cljs/sixsq/slipstream/webui/utils/resource_details.cljs
@@ -170,10 +170,6 @@
        (constantly nil)])))
 
 
-(defn operation-name [op-uri]
-  (second (re-matches #"^(?:.*/)?(.+)$" op-uri)))
-
-
 ;; Explicit keys have been added to the operation buttons to avoid react
 ;; errors for duplicate keys, which may happen when the data contains :key.
 ;; It is probably a bad idea to have a first argument that can be a map
@@ -186,7 +182,7 @@
 
 
 (defn format-operations [refresh-button {:keys [operations] :as data} baseURI description]
-  (let [ops (map (juxt #(operation-name (:rel %)) #(str baseURI (:href %)) :rel) operations)]
+  (let [ops (map (juxt #(general/operation-name (:rel %)) #(str baseURI (:href %)) :rel) operations)]
     (vec (concat [refresh-button] (map (partial operation-button data description) ops)))))
 
 


### PR DESCRIPTION
This PR updates the operations workflows for the deployment section.  Rather than redirecting to the CIMI panel afterwards, redirects stay within the deployment section.  Also clicking on stop for a deployment, no longer redirects to the details page. 

Connected to #313. 